### PR TITLE
Fix of my previous PR, removing two unnecessary lines of the license, the standard doesn't allow those lines to be there.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-MIT License
-
 Copyright (c) 2024 JSPaste
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
You can check the standard at https://opensource.org/license/mit/, that is how it should be.