### PR TITLE
use common sidecar naming

### DIFF
--- a/server.go
+++ b/server.go
@@ -17,7 +17,12 @@ func main() {
 	portEnv := getEnv("JSPF_PORT", uint16(3000)).(uint16)
 
 	fs := &fasthttp.FS{
-		FS:             www.Bundle(),
+		FS: www.Bundle(),
+		CompressedFileSuffixes: map[string]string{
+			"gzip": ".gz",
+			"br":   ".br",
+			"zstd": ".zst",
+		},
 		Compress:       true,
 		CompressBrotli: true,
 		CompressZstd:   true,

--- a/www/scripts/compress/main.go
+++ b/www/scripts/compress/main.go
@@ -16,19 +16,19 @@ var compressors = []struct {
 	writer    func(io.Writer) (io.WriteCloser, error)
 }{
 	{
-		".fasthttp.br",
+		".br",
 		func(writer io.Writer) (io.WriteCloser, error) {
 			return brotli.NewWriterLevel(writer, brotli.BestCompression), nil
 		},
 	},
 	{
-		".fasthttp.zst",
+		".zst",
 		func(writer io.Writer) (io.WriteCloser, error) {
 			return zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.SpeedBestCompression))
 		},
 	},
 	{
-		".fasthttp.gz",
+		".gz",
 		func(writer io.Writer) (io.WriteCloser, error) {
 			return gzip.NewWriterLevel(writer, gzip.BestCompression)
 		},


### PR DESCRIPTION
El deploy de CF no usa los sidecars precomprimidos, ya que tienen el formato para fasthttp para prevenir que se descompriman ficheros indeseados directamente desde el navegador. Igualmente, como no se subirán otros ficheros comprimidos aparte de los que sirvan para servir el Frontend podemos retirar y usar directamente las extensiones